### PR TITLE
feat(cms comments-service): implement create reply mutation

### DIFF
--- a/apps/CMS/comments-service/specs/mutations/create-comment.spec.ts
+++ b/apps/CMS/comments-service/specs/mutations/create-comment.spec.ts
@@ -23,15 +23,16 @@ describe('1. publishComment resolver', () => {
       entityType: 'article',
       articleId: '661c87fd6837efa536464d24',
     };
-
-    const mockedModel = jest.spyOn(CommentsModel, 'create').mockResolvedValueOnce({
+    const mockCreatedComment = {
       _id: 'test',
-    });
+      ...createInput,
+    };
+    (CommentsModel.create as jest.Mock).mockResolvedValueOnce(mockCreatedComment);
 
-    await publishComment!({}, { createInput }, {}, {} as GraphQLResolveInfo);
+    const result = await publishComment!({}, { createInput }, {}, {} as GraphQLResolveInfo);
 
     expect(CommentsModel.create).toHaveBeenCalledWith(createInput);
-    expect(mockedModel).toHaveReturned();
+    expect(result).toEqual(mockCreatedComment._id);
   });
 });
 describe('2. publishComment resolver', () => {

--- a/apps/CMS/comments-service/specs/mutations/create-reply.spec.ts
+++ b/apps/CMS/comments-service/specs/mutations/create-reply.spec.ts
@@ -1,0 +1,46 @@
+import { publishReply } from '@/graphql/resolvers/mutations';
+import { errorTypes, graphqlErrorHandler } from '../../src/graphql/resolvers/error';
+import ReplyModel from '@/models/reply.model';
+import { GraphQLResolveInfo } from 'graphql';
+
+jest.mock('@/models/reply.model', () => ({
+  create: jest.fn(),
+}));
+
+describe('publishReply resolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createInput = {
+    parentId: '',
+    reply: 'This is a test reply.',
+    commentId: '6628b347dfc5622cb34cedec',
+    name: 'John Doe',
+    email: 'johndoe@example.com',
+    createdAt: new Date('2024-04-18T12:00:00Z'),
+    ipAddress: '192.168.1.1',
+  };
+
+  it('should create reply and return its ID', async () => {
+    const mockCreatedReply = {
+      _id: 'test-reply-id',
+      ...createInput,
+    };
+
+    (ReplyModel.create as jest.Mock).mockResolvedValueOnce(mockCreatedReply);
+
+    const result = await publishReply!({}, { createInput }, {}, {} as GraphQLResolveInfo);
+
+    expect(ReplyModel.create).toHaveBeenCalledWith(createInput);
+    expect(result).toEqual(mockCreatedReply._id);
+  });
+
+  it('should throw an error if reply creation fails', async () => {
+    const mockError = graphqlErrorHandler({ message: `cannot create reply` }, errorTypes.INTERVAL_SERVER_ERROR);
+
+    (ReplyModel.create as jest.Mock).mockRejectedValueOnce(mockError);
+
+    await expect(publishReply!({}, { createInput }, {}, {} as GraphQLResolveInfo)).rejects.toThrowError(graphqlErrorHandler({ message: `cannot create reply` }, errorTypes.INTERVAL_SERVER_ERROR));
+  });
+});

--- a/apps/CMS/comments-service/src/graphql/resolvers/mutations/create-reply.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/mutations/create-reply.ts
@@ -1,0 +1,12 @@
+import { MutationResolvers } from '@/graphql/generated';
+import { errorTypes, graphqlErrorHandler } from '../error';
+import ReplyModel from '@/models/reply.model';
+
+export const publishReply: MutationResolvers['publishReply'] = async (_, { createInput }) => {
+  try {
+    const createdReply = await ReplyModel.create(createInput);
+    return createdReply._id;
+  } catch (error) {
+    throw graphqlErrorHandler({ message: `cannot create reply` }, errorTypes.INTERVAL_SERVER_ERROR);
+  }
+};

--- a/apps/CMS/comments-service/src/graphql/resolvers/mutations/index.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/mutations/index.ts
@@ -1,3 +1,4 @@
 export * from './hello-mutation';
 export * from './create-comment';
 export * from './update-comment';
+export * from './create-reply';

--- a/apps/CMS/comments-service/src/graphql/schemas/index.ts
+++ b/apps/CMS/comments-service/src/graphql/schemas/index.ts
@@ -1,5 +1,6 @@
 import { mergeTypeDefs } from '@graphql-tools/merge';
 import { helloCommentsSchema } from './hello.schema';
 import { commentsSchema } from './comment.schema';
+import { replySchema } from './reply.schema';
 
-export const typeDefs = mergeTypeDefs([helloCommentsSchema, commentsSchema]);
+export const typeDefs = mergeTypeDefs([helloCommentsSchema, commentsSchema, replySchema]);

--- a/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
+++ b/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
@@ -1,0 +1,24 @@
+import gql from 'graphql-tag';
+
+export const replySchema = gql`
+  scalar Date
+  type Reply {
+    _id: ID!
+    reply: String!
+    comment: Comment!
+    name: String!
+    parent: Reply
+    createdAt: Date
+    ipAddress: String
+  }
+  input CreateReplyInput {
+    reply: String!
+    commentId: ID!
+    parentId: ID
+    name: String!
+    email: String!
+  }
+  type Mutation {
+    publishReply(createInput: CreateReplyInput): ID!
+  }
+`;

--- a/apps/CMS/comments-service/src/models/reply.model.ts
+++ b/apps/CMS/comments-service/src/models/reply.model.ts
@@ -1,0 +1,13 @@
+import { Schema, model, models } from 'mongoose';
+
+const replySchema = new Schema({
+  parentId: { type: String, default: '' },
+  reply: { type: String, required: true },
+  commentId: { type: Schema.Types.ObjectId, ref: 'comment', required: true },
+  name: { type: String, required: true },
+  email: { type: String, required: true },
+  createdAt: { type: Date, required: true, default: new Date() },
+  ipAddress: String,
+});
+const ReplyModel = models.reply || model('reply', replySchema);
+export default ReplyModel;


### PR DESCRIPTION
## WHAT: Implement create reply mutation


## WHY: Hereglegch hen negnii setgegdeld hariulah heregtsee uusdeg


## HOW: CommentId bolon ParentId gaar tanij mongoose iin create method iig ashiglan uusgesn


## TESTING: JEST bolon LINT -r testlesen
<img width="857" alt="Screenshot 2024-04-29 at 13 13 16" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/147494260/cf837239-981c-41c1-a779-db3121985d92">
<img width="643" alt="Screenshot 2024-04-29 at 13 13 40" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/147494260/1695ab34-7ecf-4a4a-9fb5-001ab5c1b5a5">


## ANYTHING ELSE: Muu code baiwl haramgui helj ugj tuslaaraii...