### PR TITLE
feat(cms comments-service): implement get replies by commentid query

### DIFF
--- a/apps/CMS/comments-service/specs/queries/get-replies-by-commentId-query.spec.ts
+++ b/apps/CMS/comments-service/specs/queries/get-replies-by-commentId-query.spec.ts
@@ -1,0 +1,27 @@
+import { errorTypes, graphqlErrorHandler } from '@/graphql/resolvers/error';
+import { getRepliesByCommentId } from '@/graphql/resolvers/queries';
+import ReplyModel from '@/models/reply.model';
+import { GraphQLResolveInfo } from 'graphql';
+jest.mock('@/models/reply.model', () => ({
+  find: jest.fn(),
+}));
+
+describe('This query should replies by commentId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  const mock = [{ _id: 'asdf', commentId: '6628b35adfc5622cb34cedee', createdAt: new Date(), ipAddress: 'asdf', name: 'ace', parent: '', reply: 'asdf' }];
+  it('should return by commentId and return its replies', async () => {
+    jest.spyOn(ReplyModel, 'find').mockResolvedValueOnce(mock);
+    const replies = await getRepliesByCommentId!({}, { commentId: mock[0].commentId }, {}, {} as GraphQLResolveInfo);
+    expect(replies).toEqual(mock);
+  });
+  it('should return error if failed to return replies', async () => {
+    jest.spyOn(ReplyModel, 'find').mockRejectedValueOnce(graphqlErrorHandler({ message: 'cannot get replies by commentId' }, errorTypes.INTERVAL_SERVER_ERROR));
+    try {
+      await getRepliesByCommentId!({}, { commentId: mock[0].commentId }, {}, {} as GraphQLResolveInfo);
+    } catch (error) {
+      expect(error).toEqual(graphqlErrorHandler({ message: 'cannot get replies by commentId' }, errorTypes.INTERVAL_SERVER_ERROR));
+    }
+  });
+});

--- a/apps/CMS/comments-service/src/graphql/resolvers/queries/get-replies-by-commentid-query.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/queries/get-replies-by-commentid-query.ts
@@ -1,0 +1,11 @@
+import { errorTypes, graphqlErrorHandler } from '../error';
+import { QueryResolvers } from '@/graphql/generated';
+import ReplyModel from '@/models/reply.model';
+export const getRepliesByCommentId: QueryResolvers['getRepliesByCommentId'] = async (_, { commentId }) => {
+  try {
+    const replies = await ReplyModel.find({ commentId });
+    return replies;
+  } catch (error) {
+    throw graphqlErrorHandler({ message: 'cannot get replies by commentId' }, errorTypes.INTERVAL_SERVER_ERROR);
+  }
+};

--- a/apps/CMS/comments-service/src/graphql/resolvers/queries/index.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/queries/index.ts
@@ -1,2 +1,3 @@
 export * from './hello-query';
 export * from './get-comments-query';
+export * from './get-replies-by-commentid-query';

--- a/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
+++ b/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
@@ -5,7 +5,7 @@ export const replySchema = gql`
   type Reply {
     _id: ID!
     reply: String!
-    comment: Comment!
+    commentId: String!
     name: String!
     parent: Reply
     createdAt: Date
@@ -20,5 +20,8 @@ export const replySchema = gql`
   }
   type Mutation {
     publishReply(createInput: CreateReplyInput): ID!
+  }
+  type Query {
+    getRepliesByCommentId(commentId: String): [Reply]
   }
 `;


### PR DESCRIPTION
## WHAT: Implemt get replies by commentId query


## WHY: Hereglegchid comment -n doorh replies uudaas medeelel awah heregtsee shaardlaga uusdeg


## HOW: Comment iin ID gaar -n find METHOD iig ashiglan shuun awsan


## TESTING: LINT bolon YARN -r dawhar testlesen
<img width="897" alt="Screenshot 2024-04-29 at 22 11 32" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/147494260/1c3369de-87dc-4a0d-a92d-48f83a21de0b">
<img width="626" alt="Screenshot 2024-04-29 at 22 11 53" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/147494260/986a34ea-dda1-4f38-b727-8a24324a06dd">


## ANYTHING ELSE:  FEDERATION link eer test leh commentId: "6628b35adfc5622cb34cedee". Muu code baiwal haramgui zuwluj tuslaaraii