### PR TITLE
feat(cms comments-service): implement get replies by parentid query

### DIFF
--- a/apps/CMS/comments-service/specs/queries/get-replies-by-parentid-query.spec.ts
+++ b/apps/CMS/comments-service/specs/queries/get-replies-by-parentid-query.spec.ts
@@ -1,0 +1,27 @@
+import { errorTypes, graphqlErrorHandler } from '@/graphql/resolvers/error';
+import { getRepliesByParentId } from '@/graphql/resolvers/queries';
+import ReplyModel from '@/models/reply.model';
+import { GraphQLResolveInfo } from 'graphql';
+jest.mock('@/models/reply.model', () => ({
+  find: jest.fn(),
+}));
+
+describe('This query should replies by parentId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  const mock = [{ _id: 'asdf', commentId: '6628b35adfc5622cb34cedee', createdAt: new Date(), ipAddress: 'asdf', name: 'ace', parentId: '662fa126fc8ed6fdd88ace2f', reply: 'asdf' }];
+  it('should return replies by parentId and return its replies', async () => {
+    jest.spyOn(ReplyModel, 'find').mockResolvedValueOnce(mock);
+    const replies = await getRepliesByParentId!({}, { parentId: mock[0].parentId }, {}, {} as GraphQLResolveInfo);
+    expect(replies).toEqual(mock);
+  });
+  it('should return error if failed to return replies', async () => {
+    jest.spyOn(ReplyModel, 'find').mockRejectedValueOnce(graphqlErrorHandler({ message: 'cannot get replies by parentId' }, errorTypes.INTERVAL_SERVER_ERROR));
+    try {
+      await getRepliesByParentId!({}, { parentId: mock[0].parentId }, {}, {} as GraphQLResolveInfo);
+    } catch (error) {
+      expect(error).toEqual(graphqlErrorHandler({ message: 'cannot get replies by parentId' }, errorTypes.INTERVAL_SERVER_ERROR));
+    }
+  });
+});

--- a/apps/CMS/comments-service/src/graphql/resolvers/queries/get-replies-by-parentid-query.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/queries/get-replies-by-parentid-query.ts
@@ -1,0 +1,11 @@
+import { errorTypes, graphqlErrorHandler } from '../error';
+import { QueryResolvers } from '@/graphql/generated';
+import ReplyModel from '@/models/reply.model';
+export const getRepliesByParentId: QueryResolvers['getRepliesByParentId'] = async (_, { parentId }) => {
+  try {
+    const replies = await ReplyModel.find({ parentId });
+    return replies;
+  } catch (error) {
+    throw graphqlErrorHandler({ message: 'cannot get replies by parentId' }, errorTypes.INTERVAL_SERVER_ERROR);
+  }
+};

--- a/apps/CMS/comments-service/src/graphql/resolvers/queries/index.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/queries/index.ts
@@ -1,3 +1,4 @@
 export * from './hello-query';
 export * from './get-comments-query';
 export * from './get-replies-by-commentid-query';
+export * from './get-replies-by-parentid-query';

--- a/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
+++ b/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
@@ -23,5 +23,6 @@ export const replySchema = gql`
   }
   type Query {
     getRepliesByCommentId(commentId: String): [Reply]
+    getRepliesByParentId(parentId: String): [Reply]
   }
 `;


### PR DESCRIPTION
## WHAT: Implement get replies by parentid query


## WHY: Setgegdliin hariu ni door setgegdel uldeesen bol awcirj. haruulah


## HOW: ParentId bolon FIND method iig ashiglsn


## TESTING: LINT, JEST -r testlesen
<img width="899" alt="Screenshot 2024-04-30 at 11 14 38" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/147494260/9d74b2ec-ed7d-4d61-969a-58bca51cb582">
<img width="628" alt="Screenshot 2024-04-30 at 11 14 55" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/147494260/f251acf9-9beb-4f63-a2ca-11f535f02216">



## ANYTHING ELSE: Federation link eer test -leh boloh PARENTID: "662fa126fc8ed6fdd88ace2f"