### PR TITLE
feat(cms-dashboard): edit article inputs

### DIFF
--- a/apps/CMS/cms-dashboard/specs/articles/edit-article/ArrowBack.spec.tsx
+++ b/apps/CMS/cms-dashboard/specs/articles/edit-article/ArrowBack.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { ArrowBack } from '../../src/app/articles/edit-article/[id]/_components/ArrowBack';
+import { ArrowBack } from '../../../src/app/articles/edit-article/[id]/_components/ArrowBack';
 
 describe('Arrow back component', () => {
   it('1 -> should verify if arrow back component is displayed or not', () => {

--- a/apps/CMS/cms-dashboard/specs/articles/edit-article/ContentInput.spec.tsx
+++ b/apps/CMS/cms-dashboard/specs/articles/edit-article/ContentInput.spec.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import { ContentInput } from '../../../src/app/articles/edit-article/[id]/_components/ContentInput';
+
+describe('Title Input component', () => {
+  it('Component must be defined', () => {
+    const { container } = render(<ContentInput />);
+    expect(container).toBeDefined();
+  });
+});

--- a/apps/CMS/cms-dashboard/specs/articles/edit-article/SubmitButtons.spec.tsx
+++ b/apps/CMS/cms-dashboard/specs/articles/edit-article/SubmitButtons.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { SubmitButtons } from '../../src/app/articles/edit-article/[id]/_components/SubmitButtons';
+import { SubmitButtons } from '../../../src/app/articles/edit-article/[id]/_components/SubmitButtons';
 
 describe('submit buttons component', () => {
   it('1-> should check if submit buttons component renders or not', () => {

--- a/apps/CMS/cms-dashboard/specs/articles/edit-article/Title.spec.tsx
+++ b/apps/CMS/cms-dashboard/specs/articles/edit-article/Title.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { Title } from '../../src/app/articles/edit-article/[id]/_components/Title';
+import { Title } from '../../../src/app/articles/edit-article/[id]/_components/Title';
 
 describe('arrow components', () => {
   it('1-> should check arrow component is rendered or not', () => {

--- a/apps/CMS/cms-dashboard/specs/articles/edit-article/TitleInput.spec.tsx
+++ b/apps/CMS/cms-dashboard/specs/articles/edit-article/TitleInput.spec.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import { TitleInput } from '../../../src/app/articles/edit-article/[id]/_components/TitleInput';
+
+describe('Title Input component', () => {
+  it('Component must be defined', () => {
+    const { container } = render(<TitleInput />);
+    expect(container).toBeDefined();
+  });
+});

--- a/apps/CMS/cms-dashboard/src/app/articles/edit-article/[id]/_components/ContentInput.tsx
+++ b/apps/CMS/cms-dashboard/src/app/articles/edit-article/[id]/_components/ContentInput.tsx
@@ -1,0 +1,3 @@
+export const ContentInput = () => {
+  return <textarea placeholder="Type here" className="textarea textarea-bordered h-[237px] w-full"></textarea>;
+};

--- a/apps/CMS/cms-dashboard/src/app/articles/edit-article/[id]/_components/TitleInput.tsx
+++ b/apps/CMS/cms-dashboard/src/app/articles/edit-article/[id]/_components/TitleInput.tsx
@@ -1,0 +1,3 @@
+export const TitleInput = () => {
+  return <input type="text" placeholder="Type here" className="input input-bordered w-full" />;
+};

--- a/apps/CMS/cms-dashboard/src/app/articles/edit-article/[id]/page.tsx
+++ b/apps/CMS/cms-dashboard/src/app/articles/edit-article/[id]/page.tsx
@@ -2,6 +2,8 @@
 import { Article, useGetArticleByIdQuery } from '../../../../../src/generated';
 import { useParams } from 'next/navigation';
 import { SubmitButtons, Title, ToggleButtonForCommnent, ArrowBack } from './_components/index';
+import { TitleInput } from './_components/TitleInput';
+import { ContentInput } from './_components/ContentInput';
 
 const Home = () => {
   const { id } = useParams();
@@ -11,12 +13,14 @@ const Home = () => {
   const article = data?.getArticleByID as Article | undefined;
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col w-screen max-w-screen-lg gap-[20px]">
       <span>TITLE: {article?.title}</span>
       <span>CONTENT: {article?.content}</span>
       <span>CATEGORY: {article?.category.name}</span>
       <span>SLUG: {article?.slug}</span>
       <ArrowBack />
+      <TitleInput />
+      <ContentInput />
       <Title title="This is brand new" />
       <ToggleButtonForCommnent isChecked={article?.commentPermission as boolean} />
       <SubmitButtons />


### PR DESCRIPTION
created Input field (title, content)

CHECK IT 
1. navigate /dashboard 
2. check titleInput and contentInput displayed like this 
<img width="1105" alt="Screen Shot 2024-05-07 at 12 47 12" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/89830021/3b0e0a70-ce0d-4cad-9d10-33361150beb9">

THIS IS TEST SS
<img width="901" alt="Screen Shot 2024-05-07 at 12 47 46" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/89830021/df86000d-c176-442b-96fd-ee8b02e5e92a">
