### PR TITLE
perf(articles-service): added date filter on paginate

### DIFF
--- a/apps/CMS/articles-service/specs/queries/get-article-by-paginate.spec.ts
+++ b/apps/CMS/articles-service/specs/queries/get-article-by-paginate.spec.ts
@@ -1,4 +1,5 @@
 import { getArticlesByPaginate } from '@/graphql/resolvers/queries';
+import { ArticleModel } from '@/models';
 import { GraphQLResolveInfo } from 'graphql';
 
 jest.mock('../../src/models/article.model', () => ({
@@ -54,7 +55,47 @@ const mockData = {
 };
 describe('This function should return article with matching filters', () => {
   it('Should return articles with limit', async () => {
-    const result = await getArticlesByPaginate!({}, { paginationInput: { limit: 1, page: 1 }, filterInput: { status: 'status', searchedValue: 't' } }, {}, {} as GraphQLResolveInfo);
+    const result = await getArticlesByPaginate!(
+      {},
+      { paginationInput: { limit: 1, page: 1 }, filterInput: { status: 'status', searchedValue: 't', startDate: '2024-09-08', endDate: '2024-09-15' } },
+      {},
+      {} as GraphQLResolveInfo
+    );
+    expect(result).toEqual(mockData);
+  });
+  it('Should return articles with limit when startDate and endDate is null', async () => {
+    (ArticleModel.find as jest.Mock)
+      .mockReturnValueOnce({
+        populate: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            skip: jest.fn().mockResolvedValueOnce([
+              {
+                id: 'testId',
+                title: 'Title',
+                coverPhoto: 'image_uri',
+                content: 'article',
+                author: '#id1',
+                category: '#id1',
+                status: 'status',
+                slug: 'slug',
+                createdAt: '2024-09-09',
+                publishedAt: '2024-09-09',
+                updatedAt: '2024-09-09',
+                scheduledAt: '2024-09-09',
+              },
+            ]),
+          }),
+        }),
+      })
+      .mockReturnValueOnce({
+        countDocuments: jest.fn().mockResolvedValueOnce(1),
+      });
+    const result = await getArticlesByPaginate!(
+      {},
+      { paginationInput: { limit: 1, page: 1 }, filterInput: { status: 'status', searchedValue: 't', startDate: null, endDate: null } },
+      {},
+      {} as GraphQLResolveInfo
+    );
     expect(result).toEqual(mockData);
   });
 });

--- a/apps/CMS/articles-service/src/graphql/resolvers/queries/get-articles-by-paginate.ts
+++ b/apps/CMS/articles-service/src/graphql/resolvers/queries/get-articles-by-paginate.ts
@@ -1,16 +1,32 @@
 import { QueryResolvers } from '@/graphql/generated';
 import { ArticleModel } from '@/models/article.model';
 
+const buildQuery = (status: string | undefined, searchedValue: string | undefined, startDate: Date | null, endDate: Date | null) => {
+  if (startDate === null || endDate === null) {
+    return { status: { $regex: status, $options: 'i' }, title: { $regex: searchedValue, $options: 'i' } };
+  } else {
+    return {
+      status: { $regex: status, $options: 'i' },
+      title: { $regex: searchedValue, $options: 'i' },
+      createdAt: {
+        $gte: startDate,
+        $lte: endDate,
+      },
+    };
+  }
+};
+
 export const getArticlesByPaginate: QueryResolvers['getArticlesByPaginate'] = async (_, { paginationInput, filterInput }) => {
   const { limit, page } = paginationInput;
-  const { status, searchedValue } = filterInput;
+  const { status, searchedValue, startDate, endDate } = filterInput;
+  const query = buildQuery(status, searchedValue, startDate, endDate);
 
-  const articles = await ArticleModel.find({ status: { $regex: status, $options: 'i' }, title: { $regex: searchedValue, $options: 'i' } })
+  const articles = await ArticleModel.find(query)
     .populate('author category')
     .limit(limit)
     .skip(limit * (page - 1));
 
-  const totalArticles = await ArticleModel.find({ status: { $regex: status, $options: 'i' }, title: { $regex: searchedValue, $options: 'i' } }).countDocuments();
+  const totalArticles = await ArticleModel.find(query).countDocuments();
 
   return { articles, totalArticles };
 };

--- a/apps/CMS/articles-service/src/graphql/schemas/article.schema.ts
+++ b/apps/CMS/articles-service/src/graphql/schemas/article.schema.ts
@@ -41,8 +41,10 @@ export const articleSchema = gql`
   }
 
   input FilterInput {
-    status: String!
-    searchedValue: String!
+    status: String
+    searchedValue: String
+    startDate: Date
+    endDate: Date
   }
 
   type PaginationReturn {


### PR DESCRIPTION
1. added date filter on pagination query

CHECK

1. use getArticlesByPaginate query 
2. use those variables to check
{
  "paginationInput": {
    "page": 1,
    "limit": 3
  },
  "filterInput": {
    "searchedValue": "",
    "status": "",
    "startDate": "2024-04-10",
    "endDate": "2024-05-20",
  }
}