### PR TITLE
feat(cms comments-service): implement update reply mutation

### DIFF
--- a/apps/CMS/comments-service/specs/mutations/reply/update-reply.spec.ts
+++ b/apps/CMS/comments-service/specs/mutations/reply/update-reply.spec.ts
@@ -1,0 +1,34 @@
+import { errorTypes, graphqlErrorHandler } from '@/graphql/resolvers/error';
+import { updateReply } from '@/graphql/resolvers/mutations';
+import ReplyModel from '@/models/reply.model';
+import { GraphQLResolveInfo } from 'graphql';
+jest.mock('@/models/reply.model', () => ({
+  findByIdAndUpdate: jest.fn(),
+}));
+describe('update reply mutation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should update reply and return id', async () => {
+    const updateInput = { _id: '662fa120fc8ed6fdd88ace2d', reply: 'test', name: 'test', email: 'test' };
+    (ReplyModel.findByIdAndUpdate as jest.Mock).mockResolvedValueOnce(updateInput);
+    const result = await updateReply!({}, { updateInput }, {}, {} as GraphQLResolveInfo);
+    expect(result).toEqual(updateInput._id);
+    expect(ReplyModel.findByIdAndUpdate).toHaveBeenCalledWith(updateInput._id, { reply: updateInput.reply, name: updateInput.name, email: updateInput.email });
+  });
+  it('should return error when failed to update', async () => {
+    const updateInput = {
+      _id: '',
+      name: '',
+      email: '',
+      reply: '',
+    };
+    const errorMessage = graphqlErrorHandler({ message: `cannot update reply` }, errorTypes.INTERVAL_SERVER_ERROR);
+    jest.spyOn(ReplyModel, 'findByIdAndUpdate').mockRejectedValueOnce(errorMessage);
+    try {
+      await updateReply!({}, { updateInput }, {}, {} as GraphQLResolveInfo);
+    } catch (error) {
+      expect(error).toEqual(errorMessage);
+    }
+  });
+});

--- a/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/index.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/index.ts
@@ -1,1 +1,2 @@
 export * from './create-reply';
+export * from './update-reply';

--- a/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/update-reply.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/update-reply.ts
@@ -1,0 +1,13 @@
+import { MutationResolvers } from '@/graphql/generated';
+import ReplyModel from '@/models/reply.model';
+import { errorTypes, graphqlErrorHandler } from '../../error';
+
+export const updateReply: MutationResolvers['updateReply'] = async (_, { updateInput }) => {
+  const { _id, name, email, reply } = updateInput;
+  try {
+    const updatedReply = await ReplyModel.findByIdAndUpdate(_id, { name, email, reply });
+    return updatedReply._id;
+  } catch (error) {
+    throw graphqlErrorHandler({ message: `cannot update reply` }, errorTypes.INTERVAL_SERVER_ERROR);
+  }
+};

--- a/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
+++ b/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
@@ -18,8 +18,15 @@ export const replySchema = gql`
     name: String!
     email: String!
   }
+  input UpdateReplyInput {
+    _id: ID!
+    reply: String!
+    name: String!
+    email: String!
+  }
   type Mutation {
     publishReply(createInput: CreateReplyInput): ID!
+    updateReply(updateInput: UpdateReplyInput!): ID!
   }
   type Query {
     getRepliesByCommentId(commentId: String): [Reply]


### PR DESCRIPTION
## WHAT: Implement update reply mutation.


## WHY: Hereglegch uurin bichsen hariu setgegdliig update hiij chaddg baih ystoi


## HOW: Mongoose iig findByIdAndUpdate method iig ashiglaj update hiisen


## TESTING: 
<img width="622" alt="Screenshot 2024-05-28 at 11 12 32" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/147494260/d52b4b36-f9b8-4d25-a106-5ee2b5b6ef08">



## ANYTHING ELSE: Test leh bol updateReply mutation {"_id": "662fa120fc8ed6fdd88ace2d", "email": "haha", "name": "haha", "reply": "haha"}. Muu code baiwal haramgui helj uguurei.