### PR TITLE
feat(cms comments-service): implement delete reply mutation

### DIFF
--- a/apps/CMS/comments-service/specs/mutations/reply/delete-reply.spec.ts
+++ b/apps/CMS/comments-service/specs/mutations/reply/delete-reply.spec.ts
@@ -1,0 +1,34 @@
+import { errorTypes, graphqlErrorHandler } from '@/graphql/resolvers/error';
+import { deleteReply } from '@/graphql/resolvers/mutations/reply/delete-reply';
+import { accessTokenAuth } from '@/middlewares/auth-token';
+import ReplyModel from '@/models/reply.model';
+import { GraphQLResolveInfo } from 'graphql';
+jest.mock('@/models/reply.model', () => ({
+  findByIdAndDelete: jest.fn(),
+}));
+jest.mock('@/middlewares/auth-token', () => ({
+  accessTokenAuth: jest.fn(),
+}));
+
+describe('delete reply mutation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  const deleteInput = { _id: 'test' };
+  it('should delete reply by id and return its ID', async () => {
+    (accessTokenAuth as jest.Mock).mockImplementation(() => {});
+    jest.spyOn(ReplyModel, 'findByIdAndDelete').mockResolvedValue({
+      _id: 'test',
+    });
+    const result = await deleteReply!({}, { deleteInput }, {}, {} as GraphQLResolveInfo);
+    expect(result).toEqual('test');
+  });
+  it('should return error when failed to delete reply', async () => {
+    jest.spyOn(ReplyModel, 'findByIdAndDelete').mockRejectedValue(graphqlErrorHandler({ message: `cannot delete reply` }, errorTypes.INTERVAL_SERVER_ERROR));
+    try {
+      await deleteReply!({}, { deleteInput }, {}, {} as GraphQLResolveInfo);
+    } catch (error) {
+      expect(error).toEqual(graphqlErrorHandler({ message: `cannot delete reply` }, errorTypes.INTERVAL_SERVER_ERROR));
+    }
+  });
+});

--- a/apps/CMS/comments-service/specs/mutations/reply/update-reply.spec.ts
+++ b/apps/CMS/comments-service/specs/mutations/reply/update-reply.spec.ts
@@ -1,14 +1,19 @@
 import { errorTypes, graphqlErrorHandler } from '@/graphql/resolvers/error';
 import { updateReply } from '@/graphql/resolvers/mutations';
+import { accessTokenAuth } from '@/middlewares/auth-token';
 import ReplyModel from '@/models/reply.model';
 import { GraphQLResolveInfo } from 'graphql';
 jest.mock('@/models/reply.model', () => ({
   findByIdAndUpdate: jest.fn(),
 }));
+jest.mock('@/middlewares/auth-token', () => ({
+  accessTokenAuth: jest.fn(),
+}));
 describe('update reply mutation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+  (accessTokenAuth as jest.Mock).mockImplementation(() => {});
   it('should update reply and return id', async () => {
     const updateInput = { _id: '662fa120fc8ed6fdd88ace2d', reply: 'test', name: 'test', email: 'test' };
     (ReplyModel.findByIdAndUpdate as jest.Mock).mockResolvedValueOnce(updateInput);

--- a/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/delete-reply.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/delete-reply.ts
@@ -1,0 +1,14 @@
+import { MutationResolvers } from '@/graphql/generated';
+import { errorTypes, graphqlErrorHandler } from '../../error';
+import ReplyModel from '@/models/reply.model';
+import { accessTokenAuth } from '@/middlewares/auth-token';
+
+export const deleteReply: MutationResolvers['deleteReply'] = async (_, { deleteInput }, { req }) => {
+  await accessTokenAuth(req);
+  try {
+    const deletedReply = await ReplyModel.findByIdAndDelete(deleteInput._id);
+    return deletedReply._id;
+  } catch (error) {
+    throw graphqlErrorHandler({ message: `cannot delete reply` }, errorTypes.INTERVAL_SERVER_ERROR);
+  }
+};

--- a/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/index.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/index.ts
@@ -1,2 +1,3 @@
 export * from './create-reply';
 export * from './update-reply';
+export * from './delete-reply';

--- a/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/update-reply.ts
+++ b/apps/CMS/comments-service/src/graphql/resolvers/mutations/reply/update-reply.ts
@@ -1,8 +1,10 @@
 import { MutationResolvers } from '@/graphql/generated';
 import ReplyModel from '@/models/reply.model';
 import { errorTypes, graphqlErrorHandler } from '../../error';
+import { accessTokenAuth } from '@/middlewares/auth-token';
 
-export const updateReply: MutationResolvers['updateReply'] = async (_, { updateInput }) => {
+export const updateReply: MutationResolvers['updateReply'] = async (_, { updateInput }, { req }) => {
+  await accessTokenAuth(req);
   const { _id, name, email, reply } = updateInput;
   try {
     const updatedReply = await ReplyModel.findByIdAndUpdate(_id, { name, email, reply });

--- a/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
+++ b/apps/CMS/comments-service/src/graphql/schemas/reply.schema.ts
@@ -24,9 +24,13 @@ export const replySchema = gql`
     name: String!
     email: String!
   }
+  input DeleteReplyInput {
+    _id: ID!
+  }
   type Mutation {
     publishReply(createInput: CreateReplyInput): ID!
     updateReply(updateInput: UpdateReplyInput!): ID!
+    deleteReply(deleteInput: DeleteReplyInput!): ID!
   }
   type Query {
     getRepliesByCommentId(commentId: String): [Reply]


### PR DESCRIPTION
## WHAT:
1.  Implement delete reply mutation.
2.  Add auth for update reply mutation


## WHY:
1.  Hereglegch bichsn reply -aa ustgadg baih ystoi.
2. hereglegchiig shalgah shaardlaga uussen

## HOW: 
1. Mongoose iin findByIdAndDelete method iig ashiglasan ustgasn.
2. Mongoose iin findByIdAndUpdate method iig ashiglasan ustgasn


## TESTING: 
<img width="518" alt="Screenshot 2024-05-28 at 12 22 33" src="https://github.com/pinecone-studio/pinecone-intern-monorepo/assets/147494260/4fc77384-6181-4b73-a17d-84ffbf5cb82a">


## ANYTHING ELSE:
1. deleteReply mutation => {"_id": "662fa126fc8ed6fdd88ace2f"}
2. updateReply mutation => {"_id": "66305f0e8680bc47ae0d9293", "email": "haha", "name": "haha", "reply": "haha"}
deerh 2 deerh authication => Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY2MzBhYThhNTQ4NWQzYWE4M2NkMzRjNyIsIm5hbWUiOiLQpdGN0YDRjdCz0LvRjdCz0YciLCJlbWFpbCI6ImFjZUBnbWFpbC5jb20iLCJpYXQiOjE3MTQ0NjU0OTd9.-cFjed5U4TeBnLEOuoIOyJ_84UtYdpfmrzTnXjOStwE