### PR TITLE
feat(chatbot-backend): implemented createConversation mutation resolv…

### DIFF
--- a/apps/L1US/chatbot/backend/specs/resolvers/mutations/create-conversation.spec.ts
+++ b/apps/L1US/chatbot/backend/specs/resolvers/mutations/create-conversation.spec.ts
@@ -1,0 +1,62 @@
+import mongoose from 'mongoose';
+import { ConversationModel } from '../../../src/models';
+import { createConversation } from '../../../src/resolvers/mutations';
+import { GraphQLResolveInfo } from 'graphql';
+
+const validUserId = new mongoose.Types.ObjectId().toHexString();
+const input = { userId: validUserId, name: 'Test Conversation' };
+
+const mockConversation = {
+  toObject: jest.fn().mockReturnValue({
+    _id: '123',
+    userId: validUserId,
+    name: 'Test Conversation',
+  }),
+};
+
+jest.mock('../../../src/models', () => ({
+  ConversationModel: {
+    create: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/utils/catch-error', () => ({
+  catchError: jest.fn((error) => error),
+}));
+
+describe('createConversation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error for invalid userId format', async () => {
+    const input = { userId: '123', name: 'Test Conversation' };
+
+    await expect(createConversation!({}, { input }, {} as any, {} as GraphQLResolveInfo)).rejects.toThrow('Invalid userId format');
+  });
+
+  it('should create a conversation successfully', async () => {
+    (ConversationModel.create as jest.Mock).mockResolvedValue(mockConversation);
+
+    const result = await createConversation!({}, { input }, {} as any, {} as GraphQLResolveInfo);
+
+    expect(ConversationModel.create).toHaveBeenCalledWith({
+      userId: validUserId,
+      name: 'Test Conversation',
+    });
+    expect(mockConversation.toObject).toHaveBeenCalled();
+    expect(result).toEqual({
+      _id: '123',
+      userId: validUserId,
+      name: 'Test Conversation',
+    });
+  });
+
+  it('should throw an error if creation fails', async () => {
+    const error = new Error('Database failure');
+
+    (ConversationModel.create as jest.Mock).mockRejectedValue(error);
+
+    await expect(createConversation!({}, { input }, {} as any, {} as GraphQLResolveInfo)).rejects.toThrow('Database failure');
+  });
+});

--- a/apps/L1US/chatbot/backend/specs/resolvers/mutations/register-user.spec.ts
+++ b/apps/L1US/chatbot/backend/specs/resolvers/mutations/register-user.spec.ts
@@ -1,3 +1,4 @@
+import { GraphQLResolveInfo } from 'graphql';
 import { User } from '../../../src/models';
 import { registerUser } from '../../../src/resolvers/mutations';
 import { generateToken } from '../../../src/utils';
@@ -25,14 +26,14 @@ describe('registerUser', () => {
   it('should throw an error if the user already exists', async () => {
     (User.findOne as jest.Mock).mockResolvedValue({ email: input.email });
 
-    await expect(registerUser({}, { input })).rejects.toThrow('User already exists with this email or username');
+    await expect(registerUser!({}, { input }, {} as any, {} as GraphQLResolveInfo)).rejects.toThrow('User already exists with this email or username');
   });
 
   it('should create a new user and return user with token', async () => {
     (User.findOne as jest.Mock).mockResolvedValue(null);
     (User.create as jest.Mock).mockResolvedValue({ _id: '123', ...input, password: 'hashedPassword' });
 
-    const response = await registerUser({}, { input });
+    const response = await registerUser!({}, { input }, {} as any, {} as GraphQLResolveInfo);
 
     expect(User.create).toHaveBeenCalledWith({
       username: input.username,
@@ -49,6 +50,6 @@ describe('registerUser', () => {
   it('should throw an error if an unexpected error occurs', async () => {
     (User.findOne as jest.Mock).mockRejectedValue(new Error('Database error'));
 
-    await expect(registerUser({}, { input })).rejects.toThrow('Database error');
+    await expect(registerUser!({}, { input }, {} as any, {} as GraphQLResolveInfo)).rejects.toThrow('Database error');
   });
 });

--- a/apps/L1US/chatbot/backend/src/models/conversation.model.ts
+++ b/apps/L1US/chatbot/backend/src/models/conversation.model.ts
@@ -1,0 +1,11 @@
+import mongoose, { Schema } from 'mongoose';
+
+const conversationSchema = new Schema(
+  {
+    userId: { type: Schema.Types.ObjectId, required: true, ref: 'User' },
+    name: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+export const ConversationModel = mongoose.model('Conversation', conversationSchema);

--- a/apps/L1US/chatbot/backend/src/models/index.ts
+++ b/apps/L1US/chatbot/backend/src/models/index.ts
@@ -1,1 +1,2 @@
 export * from './user.model';
+export * from './conversation.model';

--- a/apps/L1US/chatbot/backend/src/resolvers/mutations/create-conversation.ts
+++ b/apps/L1US/chatbot/backend/src/resolvers/mutations/create-conversation.ts
@@ -1,0 +1,21 @@
+import mongoose from 'mongoose';
+import { MutationResolvers } from '../../generated';
+import { ConversationModel } from '../../models';
+import { catchError } from '../../utils/catch-error';
+
+export const createConversation: MutationResolvers['createConversation'] = async (_, { input }) => {
+  const { userId, name } = input;
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    throw new Error('Invalid userId format');
+  }
+
+  try {
+    const newConversation = await ConversationModel.create({
+      userId,
+      name,
+    });
+    return newConversation.toObject();
+  } catch (error) {
+    throw catchError(error);
+  }
+};

--- a/apps/L1US/chatbot/backend/src/resolvers/mutations/index.ts
+++ b/apps/L1US/chatbot/backend/src/resolvers/mutations/index.ts
@@ -1,2 +1,3 @@
 export * from './sample-mutation';
 export * from './register-user';
+export * from './create-conversation';

--- a/apps/L1US/chatbot/backend/src/resolvers/mutations/register-user.ts
+++ b/apps/L1US/chatbot/backend/src/resolvers/mutations/register-user.ts
@@ -1,11 +1,11 @@
-import { RegisterUserInput } from '../../generated';
-import { User } from '../../models';
 import bcrypt from 'bcrypt';
-import { catchError, validateRegisterUserInput, generateToken } from '../../utils';
+import { MutationResolvers } from '../../generated';
+import { User } from '../../models';
+import { catchError, generateToken, validateRegisterUserInput } from '../../utils';
 
-export const registerUser = async (_: unknown, { input }: { input: RegisterUserInput }) => {
+export const registerUser: MutationResolvers['registerUser'] = async (_, { input }) => {
   const { email, password, username } = input;
- validateRegisterUserInput(email, password);
+  validateRegisterUserInput(email, password);
 
   try {
     const existingUser = await User.findOne({ $or: [{ email }, { username }] });

--- a/apps/L1US/chatbot/backend/src/schemas/common.schema.ts
+++ b/apps/L1US/chatbot/backend/src/schemas/common.schema.ts
@@ -5,10 +5,6 @@ export const typeDefs = gql`
 
   scalar Date
 
-  enum Response {
-    Success
-  }
-
   type Query {
     sampleQuery: String!
   }

--- a/apps/L1US/chatbot/backend/src/schemas/conversation.schema.ts
+++ b/apps/L1US/chatbot/backend/src/schemas/conversation.schema.ts
@@ -1,0 +1,21 @@
+import gql from 'graphql-tag';
+
+export const ConversationTypeDefs = gql`
+  scalar Date
+
+  type Conversation {
+    userId: ID!
+    name: String
+    createdAt: Date!
+    updatedAt: Date!
+  }
+
+  input CreateConversationInput {
+    userId: ID!
+    name: String
+  }
+
+  type Mutation {
+    createConversation(input: CreateConversationInput!): Conversation!
+  }
+`;

--- a/apps/L1US/chatbot/backend/src/schemas/index.ts
+++ b/apps/L1US/chatbot/backend/src/schemas/index.ts
@@ -1,5 +1,6 @@
 import { mergeTypeDefs } from '@graphql-tools/merge';
 import { typeDefs as CommonTypeDefs } from './common.schema';
 import { UserTypeDefs } from './user.schema';
+import { ConversationTypeDefs } from './conversation.schema';
 
-export const typeDefs = mergeTypeDefs([CommonTypeDefs, UserTypeDefs]);
+export const typeDefs = mergeTypeDefs([CommonTypeDefs, UserTypeDefs, ConversationTypeDefs]);

--- a/apps/L1US/chatbot/backend/src/schemas/user.schema.ts
+++ b/apps/L1US/chatbot/backend/src/schemas/user.schema.ts
@@ -1,6 +1,8 @@
 import gql from 'graphql-tag';
 
 export const UserTypeDefs = gql`
+  scalar Date
+
   type User {
     id: ID!
     username: String!


### PR DESCRIPTION
…er and its unit test

**Description:**
- Creates a new conversation for a user by accepting a valid MongoDB userId and an optional conversation name. Validates the input and returns conversation details (userId, name, createdAt, updatedAt).

**Changes Introduced:**

- Added the createConversation mutation in resolvers/mutations.
- Uses the ConversationModel to store the conversation.
- Added error handling and Jest tests for both successful and failure cases.

**Manually Test with Apollo Explorer:**

1. Navigate to the following Apollo Explorer URL:
PREVIEW: [Apollo Preview Link](https://studio.apollographql.com/sandbox/explorer?endpoint=https://pinecone-chatbot-backend-testing-2odhkbsy2-pinecone-studio.vercel.app/api/graphql)
2. Paste the following test values in Apollo.

**Operation:**
```
mutation CreateConversation($input: CreateConversationInput!) {
  createConversation(input: $input) {
    name
    userId
    createdAt
    updatedAt
  }
}
```

**Variables:**
```
{
  "input": {
    "name": "test-conversation",
    "userId": "65f3a9d9b6e99b001fc57a3e"
  }
}
```
