### PR TITLE
feat(chatbot-backend): implemented getMessages query resolve with its…

### DIFF
--- a/apps/L1US/chatbot/backend/specs/resolvers/mutations/send-message.spec.ts
+++ b/apps/L1US/chatbot/backend/specs/resolvers/mutations/send-message.spec.ts
@@ -3,13 +3,13 @@ import { sendMessage } from '../../../src/resolvers/mutations';
 import { MessageModel } from '../../../src/models';
 import { GraphQLResolveInfo } from 'graphql';
 
-const validChatId = new mongoose.Types.ObjectId().toHexString();
-const validInput = { chatId: validChatId, query: 'Hello' };
+const validConversationId = new mongoose.Types.ObjectId().toHexString();
+const validInput = { conversationId: validConversationId, query: 'Hello' };
 
 const mockMessage = {
   toObject: jest.fn().mockReturnValue({
     _id: '123',
-    chatId: validChatId,
+    conversationId: validConversationId,
     query: 'Hello',
     response: 'Echo: Hello',
     createdAt: new Date(),
@@ -28,9 +28,9 @@ describe('sendMessage', () => {
     jest.clearAllMocks();
   });
 
-  it('should throw an error for invalid chatId format', async () => {
-    const input = { chatId: '123', query: 'Hello' };
-    await expect(sendMessage!({}, { input }, {} as any, {} as GraphQLResolveInfo)).rejects.toThrow('Invalid chatId format');
+  it('should throw an error for invalid conversationId format', async () => {
+    const input = { conversationId: '123', query: 'Hello' };
+    await expect(sendMessage!({}, { input }, {} as any, {} as GraphQLResolveInfo)).rejects.toThrow('Invalid conversationId format');
   });
 
   it('should create a message successfully', async () => {
@@ -39,14 +39,14 @@ describe('sendMessage', () => {
     const result = await sendMessage!({}, { input: validInput }, {} as any, {} as GraphQLResolveInfo);
 
     expect(MessageModel.create).toHaveBeenCalledWith({
-      chatId: validChatId,
+      conversationId: validConversationId,
       query: 'Hello',
       response: 'Echo: Hello',
     });
     expect(mockMessage.toObject).toHaveBeenCalled();
     expect(result).toEqual({
       _id: '123',
-      chatId: validChatId,
+      conversationId: validConversationId,
       query: 'Hello',
       response: 'Echo: Hello',
       createdAt: expect.any(Date),

--- a/apps/L1US/chatbot/backend/specs/resolvers/queries/get-messages.spec.ts
+++ b/apps/L1US/chatbot/backend/specs/resolvers/queries/get-messages.spec.ts
@@ -1,0 +1,50 @@
+import mongoose from 'mongoose';
+import { getMessages } from '../../../src/resolvers/queries';
+import { MessageModel } from '../../../src/models';
+import { GraphQLResolveInfo } from 'graphql';
+
+const validConversationId = new mongoose.Types.ObjectId().toHexString();
+const invalidConversationId = 'invalid-id';
+
+const mockMessage = {
+  _id: new mongoose.Types.ObjectId().toHexString(),
+  conversationId: validConversationId,
+  text: 'Hello',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+jest.mock('../../../src/models', () => ({
+  MessageModel: {
+    find: jest.fn(),
+  },
+}));
+
+describe('getMessages', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error for invalid conversationId format', async () => {
+    await expect(getMessages!({}, { conversationId: invalidConversationId }, {} as any, {} as GraphQLResolveInfo)).rejects.toThrow('Invalid conversationId format');
+  });
+
+  it('should return messages with populated conversationId', async () => {
+    (MessageModel.find as jest.Mock).mockReturnValue({
+      populate: jest.fn().mockResolvedValue([mockMessage]),
+    });
+
+    const result = await getMessages!({}, { conversationId: validConversationId }, {} as any, {} as GraphQLResolveInfo);
+
+    expect(MessageModel.find).toHaveBeenCalledWith({ conversationId: validConversationId });
+    expect(result).toEqual([mockMessage]);
+  });
+
+  it('should throw an error if fetching messages fails', async () => {
+    (MessageModel.find as jest.Mock).mockReturnValue({
+      populate: jest.fn().mockRejectedValue(new Error('Database error')),
+    });
+
+    await expect(getMessages!({}, { conversationId: validConversationId }, {} as any, {} as GraphQLResolveInfo)).rejects.toThrow('Database error');
+  });
+});

--- a/apps/L1US/chatbot/backend/src/models/message.model.ts
+++ b/apps/L1US/chatbot/backend/src/models/message.model.ts
@@ -2,7 +2,7 @@ import mongoose, { Schema } from 'mongoose';
 
 const messageSchema = new Schema(
   {
-    chatId: { type: Schema.Types.ObjectId, required: true, ref: 'Conversation' },
+    conversationId: { type: Schema.Types.ObjectId, required: true, ref: 'Conversation' },
     query: { type: String, required: true },
     response: { type: String, required: true },
   },

--- a/apps/L1US/chatbot/backend/src/resolvers/mutations/send-message.ts
+++ b/apps/L1US/chatbot/backend/src/resolvers/mutations/send-message.ts
@@ -4,15 +4,15 @@ import { MessageModel } from '../../models';
 import { catchError } from '../../utils';
 
 export const sendMessage: MutationResolvers['sendMessage'] = async (_, { input }) => {
-  const { chatId, query } = input;
-  if (!mongoose.Types.ObjectId.isValid(chatId)) {
-    throw new Error('Invalid chatId format');
+  const { conversationId, query } = input;
+  if (!mongoose.Types.ObjectId.isValid(conversationId)) {
+    throw new Error('Invalid conversationId format');
   }
   const response = `Echo: ${query}`;
-  
+
   try {
     const newMessage = await MessageModel.create({
-      chatId,
+      conversationId,
       query,
       response,
     });

--- a/apps/L1US/chatbot/backend/src/resolvers/queries/get-messages.ts
+++ b/apps/L1US/chatbot/backend/src/resolvers/queries/get-messages.ts
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+import { Message, QueryResolvers } from '../../generated';
+import { catchError } from '../../utils';
+import { MessageModel } from '../../models';
+
+export const getMessages: QueryResolvers['getMessages'] = async (_, { conversationId }) => {
+  if (!mongoose.Types.ObjectId.isValid(conversationId)) {
+    throw new Error('Invalid conversationId format');
+  }
+  try {
+    const messages = await MessageModel.find<Message>({ conversationId }).populate('conversationId');
+
+    return messages as Message[];
+  } catch (error) {
+    throw catchError(error);
+  }
+};

--- a/apps/L1US/chatbot/backend/src/resolvers/queries/index.ts
+++ b/apps/L1US/chatbot/backend/src/resolvers/queries/index.ts
@@ -1,1 +1,2 @@
 export * from './sample-query';
+export * from './get-messages';

--- a/apps/L1US/chatbot/backend/src/schemas/conversation.schema.ts
+++ b/apps/L1US/chatbot/backend/src/schemas/conversation.schema.ts
@@ -4,6 +4,7 @@ export const ConversationTypeDefs = gql`
   scalar Date
 
   type Conversation {
+    _id: ID!
     userId: ID!
     name: String
     createdAt: Date!

--- a/apps/L1US/chatbot/backend/src/schemas/message.schema.ts
+++ b/apps/L1US/chatbot/backend/src/schemas/message.schema.ts
@@ -3,8 +3,17 @@ import gql from 'graphql-tag';
 export const MessageTypeDefs = gql`
   scalar Date
 
+  type Conversation {
+    _id: ID!
+    userId: ID!
+    name: String
+    createdAt: Date!
+    updatedAt: Date!
+  }
+
   type Message {
-    chatId: ID!
+    _id: ID!
+    conversationId: Conversation!
     query: String!
     response: String!
     createdAt: Date!
@@ -12,8 +21,12 @@ export const MessageTypeDefs = gql`
   }
 
   input SendMessageInput {
-    chatId: ID!
+    conversationId: ID!
     query: String!
+  }
+
+  type Query {
+    getMessages(conversationId: ID!): [Message]
   }
 
   type Mutation {

--- a/apps/L1US/chatbot/backend/src/schemas/user.schema.ts
+++ b/apps/L1US/chatbot/backend/src/schemas/user.schema.ts
@@ -4,7 +4,7 @@ export const UserTypeDefs = gql`
   scalar Date
 
   type User {
-    id: ID!
+    _id: ID!
     username: String!
     email: String!
     password: String!


### PR DESCRIPTION
**Description:** 
- The getMessages query requires a valid MongoDB conversationId (chatId) as input. It validates the input and returns an array of messages. If no messages are found, it returns an empty array. 

**Changes Introduced:**

- Added the getMessages query in resolvers/queries.
- Uses the MessagesModel to retrieve messages for a conversation. 
- Implemented error handling and Jest tests for all branching scenarios of the query.

Test with Apollo Explorer: 

1. Navigate to the following Apollo Explorer URL: [Apollo Preview Link](https://studio.apollographql.com/sandbox/explorer?endpoint=https://pinecone-chatbot-backend-testing-8iyogwt2t-pinecone-studio.vercel.app/api/graphql) <-- Click Here

2. Paste the following test values in Apollo.

**Operation:**

```
query Query($conversationId: ID!) {
  getMessages(conversationId: $conversationId) {
    chatId
    query
    response
    createdAt
    updatedAt
  }
}
```

Variables:
```
{
  "conversationId": "67d347d21863f1a26d4ef5c9"
}
```