### PR TITLE
feat(chatbot-frontend): implement sign-up page

### DIFF
--- a/apps/L1US/chatbot/frontend/src/app/signup/page.tsx
+++ b/apps/L1US/chatbot/frontend/src/app/signup/page.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button } from '@/components/ui/button'; 
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const SignupPage = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-secondary">
+      <div className="w-full max-w-md p-10 space-y-10 rounded-md shadow-xl">
+        <h2 className="text-center text-3xl font-bold text-foreground">Sign Up</h2>
+        <form className="mt-8 space-y-6">
+          <div>
+            <Label htmlFor="email" className="block text-sm font-medium text-foreground">
+              Email Address
+            </Label>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              required
+              placeholder="Enter your email"
+              className="mt-1 block w-full"
+            />
+          </div>
+          <div>
+            <Label htmlFor="password" className="block text-sm font-medium text-foreground">
+              Password
+            </Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              required
+              placeholder="Enter your password"
+              className="mt-1 block w-full"
+            />
+          </div>
+          <div>
+            <Button type="submit" className="w-full bg-blue-500 hover:bg-blue-600">
+              Sign Up
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SignupPage;


### PR DESCRIPTION
**Description:**

- Added a generic sign-up page in the chatbot-frontend that leverages shadcn UI components. 
Note: The sign-up functionality currently serves as a prototype and does not include backend intergration.
**Changes Introduced:**
- Implemented a form with email and password fields using shadcn UI components (Button, Input, and Label)
- Created a new page at chatbot/frontend/src/app/signup/page.tsx 

**Testing Instructions:**

1. Run the application
`yarn nx serve chatbot-frontend`

2. Navigate to the Signup Page:
Open your browser and go to `http://localhost:4200/signup`