### PR TITLE
feat(interests be): interests selection added

### DIFF
--- a/apps/L1G/tinder/tinder-backend/specs/resolvers/mutations/interests/create-interest.spec.ts
+++ b/apps/L1G/tinder/tinder-backend/specs/resolvers/mutations/interests/create-interest.spec.ts
@@ -1,0 +1,21 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { createInterest } from 'src/resolvers/mutations';
+
+jest.mock('src/models/interests.model', () => ({
+  InterestsModel: {
+    create: jest.fn().mockReturnValue({
+      id: '1',
+      interestName: 'test interest',
+    }),
+  },
+}));
+
+describe('Create Interest', () => {
+  it('should create an interest', async () => {
+    const result = await createInterest!({}, { interestName: 'test interest' }, {}, {} as GraphQLResolveInfo);
+    expect(result).toEqual({
+      id: '1',
+      interestName: 'test interest',
+    });
+  });
+});

--- a/apps/L1G/tinder/tinder-backend/specs/resolvers/mutations/interests/delete-interest.spec.ts
+++ b/apps/L1G/tinder/tinder-backend/specs/resolvers/mutations/interests/delete-interest.spec.ts
@@ -1,0 +1,30 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { deleteInterest } from 'src/resolvers/mutations';
+
+jest.mock('src/models/interests.model', () => ({
+  InterestsModel: {
+    findByIdAndDelete: jest.fn().mockReturnValueOnce({
+      _id: '1',
+      interestName: 'test interest',
+    }),
+  },
+}));
+
+describe('Delete Interest', () => {
+  it('should delete an interest', async () => {
+    const result = await deleteInterest!({}, { _id: '1' }, {}, {} as GraphQLResolveInfo);
+
+    expect(result).toEqual({
+      _id: '1',
+      interestName: 'test interest',
+    });
+  });
+
+  it('should throw an error if the interest does not exist', async () => {
+    try {
+      await deleteInterest!({}, { _id: '1' }, {}, {} as GraphQLResolveInfo);
+    } catch (error) {
+      expect(error).toEqual(new Error('Interest not found'));
+    }
+  });
+});

--- a/apps/L1G/tinder/tinder-backend/specs/resolvers/mutations/interests/update-interest.spec.ts
+++ b/apps/L1G/tinder/tinder-backend/specs/resolvers/mutations/interests/update-interest.spec.ts
@@ -1,0 +1,28 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { updateInterest } from 'src/resolvers/mutations';
+
+jest.mock('src/models/interests.model', () => ({
+  InterestsModel: {
+    findByIdAndUpdate: jest.fn().mockReturnValueOnce({
+      _id: '1',
+      interestName: 'updated interest',
+    }),
+  },
+}));
+
+describe(' Update Interest', () => {
+  it('should update an interest', async () => {
+    const result = await updateInterest!({}, { _id: '1', interestName: 'updated interest' }, {}, {} as GraphQLResolveInfo);
+    expect(result).toEqual({
+      _id: '1',
+      interestName: 'updated interest',
+    });
+  });
+  it('should throw an error if the interest does not exist', async () => {
+    try {
+      await updateInterest!({}, { _id: '1', interestName: 'updated interest' }, {}, {} as GraphQLResolveInfo);
+    } catch (error) {
+      expect(error).toEqual(new Error('Interest not found'));
+    }
+  });
+});

--- a/apps/L1G/tinder/tinder-backend/specs/resolvers/queries/get-allinterests.spec.ts
+++ b/apps/L1G/tinder/tinder-backend/specs/resolvers/queries/get-allinterests.spec.ts
@@ -1,0 +1,34 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { getAllInterests } from 'src/resolvers/queries';
+
+jest.mock('src/models/interests.model', () => ({
+  InterestsModel: {
+    find: jest.fn().mockResolvedValue([
+      {
+        _id: '1',
+        interestName: 'test interest 1',
+      },
+      {
+        _id: '2',
+
+        interestName: 'test interest 2',
+      },
+    ]),
+  },
+}));
+describe('Get All Interests', () => {
+  it('should return all interests', async () => {
+    const result = await getAllInterests!({}, {}, {}, {} as GraphQLResolveInfo);
+
+    expect(result).toEqual([
+      {
+        _id: '1',
+        interestName: 'test interest 1',
+      },
+      {
+        _id: '2',
+        interestName: 'test interest 2',
+      },
+    ]);
+  });
+});

--- a/apps/L1G/tinder/tinder-backend/specs/resolvers/queries/get-interest.spec.ts
+++ b/apps/L1G/tinder/tinder-backend/specs/resolvers/queries/get-interest.spec.ts
@@ -1,0 +1,31 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { getInterest } from 'src/resolvers/queries';
+
+jest.mock('src/models/interests.model', () => ({
+  InterestsModel: {
+    findById: jest
+      .fn()
+      .mockResolvedValueOnce({
+        _id: '1',
+        interestName: 'test interest',
+      })
+      .mockReturnValueOnce(null),
+  },
+}));
+
+describe('Get Interest', () => {
+  it('should return a interest by id', async () => {
+    const result = await getInterest!({}, { _id: '1' }, {}, {} as GraphQLResolveInfo);
+
+    expect(result._id).toBe('1');
+    expect(result.interestName).toBe('test interest');
+  });
+
+  it('should throw an error if the interest does not exist', async () => {
+    try {
+      await getInterest!({}, { _id: '1' }, {}, {} as GraphQLResolveInfo);
+    } catch (error) {
+      expect(error).toEqual(new Error('Interest not found'));
+    }
+  });
+});

--- a/apps/L1G/tinder/tinder-backend/src/models/interests.model.ts
+++ b/apps/L1G/tinder/tinder-backend/src/models/interests.model.ts
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+export type Interests = {
+  _id: string;
+  interestName: string;
+};
+const InterestsSchema = new mongoose.Schema({
+  interestName: { type: String, required: true },
+});
+
+export const InterestsModel = mongoose.models.Interests || mongoose.model('Interests', InterestsSchema);

--- a/apps/L1G/tinder/tinder-backend/src/models/user.ts
+++ b/apps/L1G/tinder/tinder-backend/src/models/user.ts
@@ -10,4 +10,4 @@ const userSchema = new mongoose.Schema({
   matched: { type: [mongoose.Schema.Types.ObjectId], ref: 'User', default: [] },
 });
 
-export const Usermodel = mongoose.model('User', userSchema);
+export const Usermodel = mongoose.models.User || mongoose.model('User', userSchema);

--- a/apps/L1G/tinder/tinder-backend/src/resolvers/index.ts
+++ b/apps/L1G/tinder/tinder-backend/src/resolvers/index.ts
@@ -1,17 +1,19 @@
-import { dislike } from './mutations/dislike';
-import { like } from './mutations/like';
-import { login } from './mutations/login';
-import { signup } from './mutations/signup';
-import { getusers } from './queries/getusers';
+import { login, signup, like, createInterest, updateInterest, deleteInterest, dislike } from './mutations';
+import { getAllInterests, getInterest, getusers } from './queries';
 
 export const resolvers = {
   Query: {
     getusers,
+    getAllInterests,
+    getInterest,
   },
   Mutation: {
     login,
     signup,
     like,
+    createInterest,
+    updateInterest,
+    deleteInterest,
     dislike,
   },
 };

--- a/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/index.ts
+++ b/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/index.ts
@@ -1,0 +1,5 @@
+export * from './interests';
+export * from './dislike';
+export * from './like';
+export * from './login';
+export * from './signup';

--- a/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/interests/create-interest.ts
+++ b/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/interests/create-interest.ts
@@ -1,0 +1,8 @@
+import { MutationResolvers } from 'src/generated';
+import { InterestsModel } from 'src/models/interests.model';
+
+export const createInterest: MutationResolvers['createInterest'] = async (_, { interestName }) => {
+  const createdInterest = await InterestsModel.create({ interestName });
+
+  return createdInterest;
+};

--- a/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/interests/delete-interest.ts
+++ b/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/interests/delete-interest.ts
@@ -1,0 +1,11 @@
+import { MutationResolvers } from 'src/generated';
+import { InterestsModel } from 'src/models/interests.model';
+
+export const deleteInterest: MutationResolvers['deleteInterest'] = async (_, { _id }) => {
+  const deletedInterest = await InterestsModel.findByIdAndDelete(_id);
+
+  if (!deletedInterest) {
+    throw new Error('Interest not found');
+  }
+  return deletedInterest;
+};

--- a/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/interests/index.ts
+++ b/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/interests/index.ts
@@ -1,0 +1,3 @@
+export * from './create-interest';
+export * from './update-interest';
+export * from './delete-interest';

--- a/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/interests/update-interest.ts
+++ b/apps/L1G/tinder/tinder-backend/src/resolvers/mutations/interests/update-interest.ts
@@ -1,0 +1,12 @@
+import { MutationResolvers } from 'src/generated';
+import { InterestsModel } from 'src/models/interests.model';
+
+export const updateInterest: MutationResolvers['updateInterest'] = async (_, { _id, interestName }) => {
+  const updatedInterest = await InterestsModel.findByIdAndUpdate(_id, { interestName }, { new: true });
+
+  if (!updatedInterest) {
+    throw new Error('Interest not found');
+  }
+
+  return updatedInterest;
+};

--- a/apps/L1G/tinder/tinder-backend/src/resolvers/queries/get-allinterests.ts
+++ b/apps/L1G/tinder/tinder-backend/src/resolvers/queries/get-allinterests.ts
@@ -1,0 +1,8 @@
+import { InterestsModel } from 'src/models/interests.model';
+import { QueryResolvers } from 'src/generated';
+
+export const getAllInterests: QueryResolvers['getAllInterests'] = async () => {
+  const allInterests = await InterestsModel.find({});
+
+  return allInterests;
+};

--- a/apps/L1G/tinder/tinder-backend/src/resolvers/queries/get-interest.ts
+++ b/apps/L1G/tinder/tinder-backend/src/resolvers/queries/get-interest.ts
@@ -1,0 +1,12 @@
+import { QueryResolvers } from 'src/generated';
+import { InterestsModel } from 'src/models/interests.model';
+
+export const getInterest: QueryResolvers['getInterest'] = async (_, { _id }) => {
+  const interest = await InterestsModel.findById(_id);
+
+  if (!interest) {
+    throw new Error('Interest not found');
+  }
+
+  return interest;
+};

--- a/apps/L1G/tinder/tinder-backend/src/resolvers/queries/index.ts
+++ b/apps/L1G/tinder/tinder-backend/src/resolvers/queries/index.ts
@@ -1,0 +1,3 @@
+export * from './get-allinterests';
+export * from './get-interest';
+export * from './getusers';

--- a/apps/L1G/tinder/tinder-backend/src/schemas/index.ts
+++ b/apps/L1G/tinder/tinder-backend/src/schemas/index.ts
@@ -1,4 +1,5 @@
 import { mergeTypeDefs } from '@graphql-tools/merge';
 import { UsertypeDefs } from './user';
+import { InterestsTypeDefs } from './interests.schema';
 
-export const typeDefs = mergeTypeDefs([UsertypeDefs]);
+export const typeDefs = mergeTypeDefs([UsertypeDefs, InterestsTypeDefs]);

--- a/apps/L1G/tinder/tinder-backend/src/schemas/interests.schema.ts
+++ b/apps/L1G/tinder/tinder-backend/src/schemas/interests.schema.ts
@@ -1,0 +1,16 @@
+import { gql } from 'apollo-server-cloud-functions';
+export const InterestsTypeDefs = gql`
+  type Interest {
+    _id: ID!
+    interestName: String!
+  }
+  type Query {
+    getInterest(_id: ID!): Interest!
+    getAllInterests: [Interest!]!
+  }
+  type Mutation {
+    createInterest(interestName: String!): Interest!
+    updateInterest(_id: ID!, interestName: String!): Interest!
+    deleteInterest(_id: ID!): Interest!
+  }
+`;


### PR DESCRIPTION
<img width="2160" height="1165" alt="Screenshot 2025-08-06 at 16 45 01" src="https://github.com/user-attachments/assets/e8d77bda-d529-494a-9c2f-248fff84e2fa" />

Shineer uusgesen files:
- interests.model
- interests.schema
- mutations [create-interest, update-interest, delete-interest]
- queries [get-allinterests, get-interest]
- all tests 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing user interests, including creating, updating, deleting, and retrieving interests through new GraphQL queries and mutations.
  * Introduced a new Interest type to the GraphQL schema, enabling interest-related operations.

* **Bug Fixes**
  * Improved model export logic to prevent errors when importing models multiple times.

* **Tests**
  * Added comprehensive tests for all interest-related query and mutation resolvers to ensure correct functionality and error handling.

* **Documentation**
  * Extended GraphQL schema documentation to include interest management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->