### PR TITLE
fix: OTP mail minute fixed

### DIFF
--- a/apps/L1G/tinder/tinder-backend/src/utils/send-otp-email.ts
+++ b/apps/L1G/tinder/tinder-backend/src/utils/send-otp-email.ts
@@ -15,6 +15,6 @@ export const sendOtpEmail = async (to: string, otp: string) => {
     from: process.env.OTP_EMAIL,
     to,
     subject: 'Your OTP Code',
-    html: `<p>Your OTP code is: <strong>${otp}</strong>. It is valid for 10 minutes.</p>`,
+    html: `<p>Your OTP code is: <strong>${otp}</strong>. It is valid for 1 minute.</p>`,
   });
 };


### PR DESCRIPTION
OTP email valid minute fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OTP email message to state that codes are valid for 1 minute (was 10 minutes), aligning user notification with current security policy and preventing confusion. Users should now expect OTPs to expire quickly and act promptly, improving clarity and reducing failed sign-ins due to outdated expectations. No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->